### PR TITLE
Call setAccessible only once

### DIFF
--- a/src/main/java/ysoserial/payloads/util/Reflections.java
+++ b/src/main/java/ysoserial/payloads/util/Reflections.java
@@ -7,10 +7,10 @@ public class Reflections {
 
 	public static Field getField(final Class<?> clazz, final String fieldName) throws Exception {
 		Field field = clazz.getDeclaredField(fieldName);
-		if (field == null && clazz.getSuperclass() != null) {
+		if (field != null)
+			field.setAccessible(true);
+		else if (clazz.getSuperclass() != null)
 			field = getField(clazz.getSuperclass(), fieldName);
-		}
-		field.setAccessible(true);
 		return field;
 	}
 


### PR DESCRIPTION
In the getField method, due to recursion, the field.setAccessible was called a number of times equal to the number of level to go up the hierarchy to find the field