### PR TITLE
Add xstream serializer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,11 @@
 			<artifactId>remoting-jmx</artifactId>
 			<version>2.0.1.Final</version>
 		</dependency>
+        <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.10</version>
+        </dependency>
 
 		<!-- gadget dependecies -->
 

--- a/src/main/java/ysoserial/GeneratePayload.java
+++ b/src/main/java/ysoserial/GeneratePayload.java
@@ -14,12 +14,14 @@ public class GeneratePayload {
 	private static final int USAGE_CODE = 64;
 
 	public static void main(final String[] args) {
-		if (args.length != 2) {
+		if (args.length != 2 && args.length != 3) {
 			printUsage();
 			System.exit(USAGE_CODE);
 		}
 		final String payloadType = args[0];
 		final String command = args[1];
+        final boolean xstreamDeserialization = (args.length == 3) && args[2].equals("-xstream");
+
 
 		final Class<? extends ObjectPayload> payloadClass = Utils.getPayloadClass(payloadType);
 		if (payloadClass == null) {
@@ -33,7 +35,13 @@ public class GeneratePayload {
 			final ObjectPayload payload = payloadClass.newInstance();
 			final Object object = payload.getObject(command);
 			PrintStream out = System.out;
-			Serializer.serialize(object, out);
+
+			if(xstreamDeserialization){
+			    Serializer.serializeXstream(object, out);
+            }else{
+                Serializer.serialize(object, out);
+            }
+
 			ObjectPayload.Utils.releasePayload(payload, object);
 		} catch (Throwable e) {
 			System.err.println("Error while generating or serializing payload");
@@ -45,7 +53,7 @@ public class GeneratePayload {
 
 	private static void printUsage() {
 		System.err.println("Y SO SERIAL?");
-		System.err.println("Usage: java -jar ysoserial-[version]-all.jar [payload] '[command]'");
+		System.err.println("Usage: java -jar ysoserial-[version]-all.jar [payload] '[command]' [-xstream]");
 		System.err.println("  Available payload types:");
 
 		final List<Class<? extends ObjectPayload>> payloadClasses =

--- a/src/main/java/ysoserial/Serializer.java
+++ b/src/main/java/ysoserial/Serializer.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.util.concurrent.Callable;
+import com.thoughtworks.xstream.XStream;
 
 public class Serializer implements Callable<byte[]> {
 	private final Object object;
@@ -26,5 +27,11 @@ public class Serializer implements Callable<byte[]> {
 		final ObjectOutputStream objOut = new ObjectOutputStream(out);
 		objOut.writeObject(obj);
 	}
+
+	public static void serializeXstream(final Object obj, final OutputStream out) throws IOException{
+        XStream xstream = new XStream();
+        String serialized = xstream.toXML(obj);
+        out.write(serialized.getBytes());
+    }
 
 }


### PR DESCRIPTION
I recently used this project to generate xstream payloads for a POC I wrote. I added an extra command line option to allow users to specify xstream serialization, and a corresponding function in the Serializer class to serialize to XML rather than builtin Java serialization. Was hoping there would be interest in incorporating these changes in the main repository.