### PR TITLE
Added Timestamps to JRMPListener exploit output

### DIFF
--- a/src/main/java/ysoserial/exploit/JRMPListener.java
+++ b/src/main/java/ysoserial/exploit/JRMPListener.java
@@ -21,6 +21,8 @@ import java.rmi.MarshalException;
 import java.rmi.server.ObjID;
 import java.rmi.server.UID;
 import java.util.Arrays;
+import java.util.Date;
+import java.text.SimpleDateFormat;
 
 import javax.management.BadAttributeValueExpException;
 import javax.net.ServerSocketFactory;
@@ -75,7 +77,7 @@ public class JRMPListener implements Runnable {
             if ( this.hadConnection ) {
                 return true;
             }
-            System.err.println("Waiting for connection");
+            printLogEntry("Waiting for connection");
             synchronized ( this.waitLock ) {
                 this.waitLock.wait(i);
             }
@@ -114,7 +116,7 @@ public class JRMPListener implements Runnable {
 
         try {
             int port = Integer.parseInt(args[ 0 ]);
-            System.err.println("* Opening JRMP listener on " + port);
+            printLogEntry("* Opening JRMP listener on " + port);
             JRMPListener c = new JRMPListener(port, payloadObject);
             c.run();
         }
@@ -134,7 +136,7 @@ public class JRMPListener implements Runnable {
                     try {
                         s.setSoTimeout(5000);
                         InetSocketAddress remote = (InetSocketAddress) s.getRemoteSocketAddress();
-                        System.err.println("Have connection from " + remote);
+                        printLogEntry("Have connection from " + remote);
 
                         InputStream is = s.getInputStream();
                         InputStream bufIn = is.markSupported() ? is : new BufferedInputStream(is);
@@ -172,7 +174,7 @@ public class JRMPListener implements Runnable {
                             break;
                         default:
                         case TransportConstants.MultiplexProtocol:
-                            System.err.println("Unsupported protocol");
+                            printLogEntry("Unsupported protocol");
                             s.close();
                             continue;
                         }
@@ -187,7 +189,7 @@ public class JRMPListener implements Runnable {
                         e.printStackTrace(System.err);
                     }
                     finally {
-                        System.err.println("Closing connection");
+                        printLogEntry("Closing connection");
                         s.close();
                     }
 
@@ -214,7 +216,7 @@ public class JRMPListener implements Runnable {
 
 
     private void doMessage ( Socket s, DataInputStream in, DataOutputStream out, Object payload ) throws Exception {
-        System.err.println("Reading message...");
+        printLogEntry("Reading message...");
 
         int op = in.read();
 
@@ -269,10 +271,10 @@ public class JRMPListener implements Runnable {
         if ( read.hashCode() == 2 ) {
             ois.readInt(); // method
             ois.readLong(); // hash
-            System.err.println("Is DGC call for " + Arrays.toString((ObjID[])ois.readObject()));
+            printLogEntry("Is DGC call for " + Arrays.toString((ObjID[])ois.readObject()));
         }
 
-        System.err.println("Sending return with payload for obj " + read);
+        printLogEntry("Sending return with payload for obj " + read);
 
         out.writeByte(TransportConstants.Return);// transport op
         ObjectOutputStream oos = new JRMPClient.MarshalOutputStream(out, this.classpathUrl);
@@ -309,6 +311,11 @@ public class JRMPListener implements Runnable {
         }
     }
 
+    private static void printLogEntry(String message) {
+        Date now = new Date();
+        SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
+        System.err.println(sdf.format(now)+": "+message);
+    }
 
     public static class Dummy implements Serializable {
         private static final long serialVersionUID = 1L;


### PR DESCRIPTION
I have found that when using JRMPListener, there is sometimes a delay between when the vulnerable system receives a payload and when the vulnerable system contacts the JRMPListener listener. It is also normal for the vulnerable system to contact the JRMPListener multiple times after receiving a single payload. Because of these factors, it can be beneficial to know exactly when contact was made between the vulnerable system and the JRMPListener.

The current output from JRMPListener does not contain any timestamps. I have added date (MM/DD/YYYY) and time (HH:MM:SS) timestamps to the ysoserial.exploit.JRMPListener class like so: "11/03/2018 21:39:44: Have connection from /192.168.0.18:25307"