### PR TITLE
Add Hibernate 5.3.11 compile profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,6 +383,27 @@
 		</profile>
 
 		<profile>
+			<id>hibernate5.3.11</id>
+			<activation>
+				<property>
+					<name>hibernate5.3.11</name>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>org.hibernate</groupId>
+					<artifactId>hibernate-core</artifactId>
+					<version>5.3.11.Final</version>
+				</dependency>
+                <dependency>
+                    <groupId>javax.el</groupId>
+                    <artifactId>javax.el-api</artifactId>
+                    <version>3.0.0</version>
+                </dependency>
+			</dependencies>
+		</profile>
+
+		<profile>
 			<id>apache-el</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>


### PR DESCRIPTION
Adding a maven profile option to compile with Hibernate 5.3.11, example:

`mvn clean package -DskipTests -Dhibernate5.3.11`

Exploiting hibernate 5 works just as before:

`java -Dhibernate5 -jar target/ysoserial-0.0.6-SNAPSHOT-all.jar Hibernate1 "touch /tmp/ysoserial"`