### PR TITLE
Just call setAccessible with Java > 12

### DIFF
--- a/src/main/java/ysoserial/payloads/util/Reflections.java
+++ b/src/main/java/ysoserial/payloads/util/Reflections.java
@@ -13,8 +13,18 @@ import com.nqzero.permit.Permit;
 public class Reflections {
 
     public static void setAccessible(AccessibleObject member) {
-        // quiet runtime warnings from JDK9+
-        Permit.setAccessible(member);
+        String versionStr = System.getProperty("java.version");
+        int javaVersion = Integer.parseInt(versionStr.split("\\.")[0]);
+        if (javaVersion < 12) {
+          // quiet runtime warnings from JDK9+
+          Permit.setAccessible(member);
+        } else {
+          // not possible to quiet runtime warnings anymore...
+          // see https://bugs.openjdk.java.net/browse/JDK-8210522
+          // to understand impact on Permit (i.e. it does not work
+          // anymore with Java >= 12)
+          member.setAccessible(true);
+        }
     }
 
 	public static Field getField(final Class<?> clazz, final String fieldName) {


### PR DESCRIPTION
Fix for Java >= 12.

Error message before the fix  is:

Error while generating or serializing payload
com.nqzero.permit.Permit$InitializationFailed: initialization failed, perhaps you're running with a security manager
	at com.nqzero.permit.Permit.setAccessible(Permit.java:22)
	at ysoserial.payloads.util.Reflections.setAccessible(Reflections.java:17)
	at ysoserial.payloads.util.Reflections.getField(Reflections.java:24)
	at ysoserial.payloads.BeanShell1.getObject(BeanShell1.java:45)
	at ysoserial.payloads.BeanShell1.getObject(BeanShell1.java:22)
	at ysoserial.GeneratePayload.main(GeneratePayload.java:34)
Caused by: com.nqzero.permit.Permit$FieldNotFound: field "override" not found
	at com.nqzero.permit.Permit.<init>(Permit.java:222)
	at com.nqzero.permit.Permit.build(Permit.java:117)
	at com.nqzero.permit.Permit.<clinit>(Permit.java:16)
	... 5 more