### PR TITLE
fix jdk6 protocol errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,13 +355,13 @@
             <repositories>
                 <repository>
                     <id>repo1</id>
-                    <url>https://repo1.maven.org/maven2</url>
+                    <url>http://repo1.maven.org/maven2</url><!-- intentionally http (see above) -->
                 </repository>
             </repositories>
             <pluginRepositories>
                 <pluginRepository>
                     <id>repo1</id>
-                    <url>https://repo1.maven.org/maven2</url>
+                    <url>http://repo1.maven.org/maven2</url><!-- intentionally http (see above) -->
                 </pluginRepository>
             </pluginRepositories>
         </profile>


### PR DESCRIPTION
Revert #139 and #144 to use HTTP to retrieve artifacts for JDK 1.6 only.