### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ after_script:
       grep testcase -A1 | grep -B1 -E 'failure|error|skipped' | grep -v -- --
 
 matrix:
+  fast_finish: true
   allow_failures:
     - jdk: oraclejdk11
     - jdk: openjdk6


### PR DESCRIPTION

According to the official document [Fast Finishing](https://docs.travis-ci.com/user/build-matrix/#fast-finishing), if some rows in the build matrix are allowed to fail, we can add fast_finish: true to the .travis.yml to get faster feedbacks.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
