### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY src ./src
 RUN mvn clean package -DskipTests
 RUN mv target/ysoserial-*all*.jar target/ysoserial.jar
 
-FROM java:8-jdk-alpine
+FROM openjdk:8-jdk-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
There is no image named, openjdk:8-alpine hosted in Docker,  I just replace java for openjdk and it works 

Error Step 11/14: FROM java:8-jdk-alpine
manifest for java: 8-jdk-alpine not found: unknown manifest: unknown manifest

Step 11/14 : FROM openjdk:8-jdk-alpine
8-jdk-alpine: Pulling from library/openjdk
e7c96db7181b: Pull complete
f910a506b6cb: Pull complete
c2274a1a0e27: Pull complete
Digest: sha256:94792824df2df33402f201713f932b58cb9de94a0cd524164a0f2283343547b3
Status: Downloaded newer image for openjdk:8-jdk-alpine