### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY src ./src
 RUN mvn clean package -DskipTests
 RUN mv target/ysoserial-*all*.jar target/ysoserial.jar
 
-FROM java:8-jdk-alpine
+FROM openjdk:8-jdk-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
fix following error

```
ERROR: failed to solve: java:8-jdk-alpine: docker.io/library/java:8-jdk-alpine: not found
```