### PR TITLE
Change base image to eclipse-temurin:8-jdk-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY src ./src
 RUN mvn clean package -DskipTests
 RUN mv target/ysoserial-*all*.jar target/ysoserial.jar
 
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:8-jdk-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR fixes an issue during the Docker build with the existent Dockerfile.
The image openjdk:8-jdk-alpine doesn't exist anymore and the current Dockerfile return the following error

```
Step 11/14 : FROM openjdk:8-jdk-alpine
manifest for openjdk:8-jdk-alpine not found: manifest unknown: manifest unknown
```

I updated the Dockerfile with the image eclipse-temurin:8-jdk-alpine to workaround the issue.